### PR TITLE
feat: enforce OVOS-CONTEXT-1 requires/excludes_context gating

### DIFF
--- a/nebulento/opm.py
+++ b/nebulento/opm.py
@@ -10,6 +10,7 @@ from ovos_bus_client.session import SessionManager, Session
 from ovos_config.config import Configuration
 from ovos_plugin_manager.templates.pipeline import ConfidenceMatcherPipeline, IntentHandlerMatch
 from ovos_spec_tools import SpecMessage, closest_lang, standardize_lang
+from ovos_spec_tools.context import gate_satisfied
 from ovos_utils import flatten_list
 from ovos_utils.fakebus import FakeBus
 from ovos_utils.log import LOG
@@ -110,7 +111,36 @@ class NebulentoPipeline(ConfidenceMatcherPipeline):
         # INTENT-4 §8.5 — intents disabled without losing their definition;
         # excluded from match candidacy until re-enabled.
         self.disabled_intents: set = set()
+        # OVOS-CONTEXT-1 §6 — per-intent gating contracts, keyed by the
+        # internal ``skill_id:name`` label. Declarations are optional; absent
+        # keys mean "no gate". gate_satisfied() enforces liveness/scope/decay.
+        self.requires_context: Dict[str, list] = {}
+        self.excludes_context: Dict[str, list] = {}
         LOG.debug("Loaded Nebulento pipeline")
+
+    def _store_context_gates(self, name: str, message) -> None:
+        """Record OVOS-CONTEXT-1 gating contracts declared on registration.
+
+        ``requires_context``/``excludes_context`` are each an optional list of
+        bare-string keys or ``{"key", "scope"}`` mappings. Stored verbatim and
+        handed to :func:`gate_satisfied` at match time.
+        """
+        requires = message.data.get("requires_context")
+        excludes = message.data.get("excludes_context")
+        if requires:
+            self.requires_context[name] = requires
+        if excludes:
+            self.excludes_context[name] = excludes
+
+    def _context_gate_ok(self, name: str, sess) -> bool:
+        """OVOS-CONTEXT-1 §6 gate for candidate intent *name* under *sess*."""
+        requires = self.requires_context.get(name)
+        excludes = self.excludes_context.get(name)
+        if not requires and not excludes:
+            return True
+        skill_id = name.split(":")[0]
+        return gate_satisfied(sess.intent_context or {}, requires, excludes,
+                              owner_id=skill_id)
 
     def train(self, message=None):
         """No training required — emit trained signal immediately."""
@@ -195,6 +225,7 @@ class NebulentoPipeline(ConfidenceMatcherPipeline):
             return
         name = message.data["name"]
         self.registered_intents.append(name)
+        self._store_context_gates(name, message)
         container = self.containers[lang]
         try:
             self._register_object(
@@ -255,6 +286,7 @@ class NebulentoPipeline(ConfidenceMatcherPipeline):
                         f"empty samples")
             return
         self.registered_intents.append(name)
+        self._store_context_gates(name, message)
         container = self.containers[lang]
         try:
             self._add_intent(container, name, samples)
@@ -324,6 +356,8 @@ class NebulentoPipeline(ConfidenceMatcherPipeline):
     def _detach_intent(self, intent_name: str):
         if intent_name in self.registered_intents:
             self.registered_intents.remove(intent_name)
+            self.requires_context.pop(intent_name, None)
+            self.excludes_context.pop(intent_name, None)
             for container in self.containers.values():
                 self._remove_intent(container, intent_name)
 
@@ -389,6 +423,9 @@ class NebulentoPipeline(ConfidenceMatcherPipeline):
         # INTENT-4 §8.5 — disabled intents are excluded from match candidacy
         results = [r for r in results
                    if r is not None and r.name not in self.disabled_intents]
+        # OVOS-CONTEXT-1 §6 — drop candidates whose requires/excludes gate is
+        # not satisfied by the session's live intent_context.
+        results = [r for r in results if self._context_gate_ok(r.name, sess)]
         return max(results, key=lambda r: r.conf) if results else None
 
     def _get_closest_lang(self, lang: str) -> Optional[str]:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ requires-python = ">=3.10"
 dependencies = [
     "rapidfuzz",
     "quebra_frases",
-    "ovos-spec-tools>=0.16.1a2",
+    "ovos-spec-tools>=1.4.0a1",
     "ovos-utils",
 ]
 

--- a/test/test_opm.py
+++ b/test/test_opm.py
@@ -3,6 +3,7 @@ import unittest
 from unittest import mock
 
 from ovos_bus_client.message import Message
+from ovos_bus_client.session import Session
 
 from nebulento.opm import HierarchicalNebulentoPipeline, NebulentoPipeline
 
@@ -403,6 +404,117 @@ class TestNebulentoPipelineIntent4(unittest.TestCase):
         self.assertIn("ovos.intent.register.template", removed)
         self.assertIn("ovos.entity.register", removed)
         self.assertIn("ovos.intent.disable", removed)
+
+
+def _utt_msg(utt, session=None, lang="en-US"):
+    ctx = {"session": session.serialize()} if session is not None else {}
+    return Message("recognizer_loop:utterance",
+                   {"utterances": [utt], "lang": lang}, ctx)
+
+
+class TestNebulentoContextGating(unittest.TestCase):
+    """OVOS-CONTEXT-1 §6 requires_context / excludes_context gating."""
+
+    def setUp(self):
+        self.bus = mock.Mock()
+        self.pipeline = NebulentoPipeline(bus=self.bus, config={
+            "conf_high": 0.95, "conf_med": 0.8, "conf_low": 0.5,
+        })
+
+    def _session(self, intent_context):
+        s = Session("ctx-test")
+        s.intent_context = intent_context
+        return s
+
+    def test_requires_context_present_matches(self):
+        self.pipeline.register_intent(Message("padatious:register_intent", {
+            "name": "test_skill:HelloIntent",
+            "samples": ["hello"], "lang": "en-US",
+            "requires_context": ["game_active"],
+        }))
+        # private scope → stored under "<skill_id>:<key>"
+        sess = self._session({"test_skill:game_active": {"value": True}})
+        result = self.pipeline.match_high(["hello"], "en-US",
+                                          _utt_msg("hello", sess))
+        self.assertIsNotNone(result)
+        self.assertEqual(result.match_type, "test_skill:HelloIntent")
+
+    def test_requires_context_absent_drops(self):
+        self.pipeline.register_intent(Message("padatious:register_intent", {
+            "name": "test_skill:HelloIntent",
+            "samples": ["hello"], "lang": "en-US",
+            "requires_context": ["game_active"],
+        }))
+        sess = self._session({})  # required key not live
+        result = self.pipeline.match_high(["hello"], "en-US",
+                                          _utt_msg("hello", sess))
+        self.assertIsNone(result)
+
+    def test_excludes_context_present_drops(self):
+        self.pipeline.register_intent(Message("padatious:register_intent", {
+            "name": "test_skill:HelloIntent",
+            "samples": ["hello"], "lang": "en-US",
+            "excludes_context": ["muted"],
+        }))
+        sess = self._session({"test_skill:muted": {"value": True}})
+        result = self.pipeline.match_high(["hello"], "en-US",
+                                          _utt_msg("hello", sess))
+        self.assertIsNone(result)
+
+    def test_excludes_context_absent_matches(self):
+        self.pipeline.register_intent(Message("padatious:register_intent", {
+            "name": "test_skill:HelloIntent",
+            "samples": ["hello"], "lang": "en-US",
+            "excludes_context": ["muted"],
+        }))
+        sess = self._session({})
+        result = self.pipeline.match_high(["hello"], "en-US",
+                                          _utt_msg("hello", sess))
+        self.assertIsNotNone(result)
+
+    def test_no_gate_declared_always_matches(self):
+        self.pipeline.register_intent(Message("padatious:register_intent", {
+            "name": "test_skill:HelloIntent",
+            "samples": ["hello"], "lang": "en-US",
+        }))
+        result = self.pipeline.match_high(["hello"], "en-US",
+                                          _utt_msg("hello"))
+        self.assertIsNotNone(result)
+
+    def test_shared_scope_requires_context(self):
+        self.pipeline.register_intent(Message("padatious:register_intent", {
+            "name": "test_skill:HelloIntent",
+            "samples": ["hello"], "lang": "en-US",
+            "requires_context": [{"key": "party_mode", "scope": "shared"}],
+        }))
+        # shared scope → stored under the bare key
+        sess = self._session({"party_mode": {"value": True}})
+        result = self.pipeline.match_high(["hello"], "en-US",
+                                          _utt_msg("hello", sess))
+        self.assertIsNotNone(result)
+
+    def test_template_registration_stores_gates(self):
+        self.pipeline.handle_register_template(Message(
+            "ovos.intent.register.template", {
+                "skill_id": "test_skill", "intent_name": "HelloIntent",
+                "lang": "en-US", "samples": ["hello"],
+                "requires_context": ["game_active"],
+            }))
+        self.assertEqual(self.pipeline.requires_context.get("test_skill:HelloIntent"),
+                         ["game_active"])
+        sess = self._session({})
+        self.assertIsNone(self.pipeline.match_high(
+            ["hello"], "en-US", _utt_msg("hello", sess)))
+
+    def test_detach_clears_gates(self):
+        self.pipeline.register_intent(Message("padatious:register_intent", {
+            "name": "test_skill:HelloIntent",
+            "samples": ["hello"], "lang": "en-US",
+            "requires_context": ["game_active"],
+        }))
+        self.pipeline.handle_detach_intent(
+            Message("detach_intent", {"intent_name": "test_skill:HelloIntent"}))
+        self.assertNotIn("test_skill:HelloIntent", self.pipeline.requires_context)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Enforces OVOS-CONTEXT-1 §6 `requires_context` / `excludes_context` gating in the nebulento pipeline.

## What

- Registration MAY carry optional `requires_context` / `excludes_context`, each a list of bare-string keys or `{"key","scope":"private"|"shared"}` mappings (default private scope). Arrives on the INTENT-4 `ovos.intent.register.template` topic and the legacy `padatious:register_intent` topic. Stored per registered intent, keyed by the internal `skill_id:name` label.
- At match time, after a candidate is chosen, it is dropped when `gate_satisfied(session.intent_context or {}, requires, excludes, owner_id=skill_id)` returns False. Liveness / scope / decay are delegated entirely to `ovos_spec_tools.context.gate_satisfied` — not reimplemented here.
- Additive and back-compat: intents without declarations behave exactly as before. Gates are cleared on intent detach.

## spec-tools floor

Raises the `ovos-spec-tools` floor to `>=1.4.0a1` for the new `ovos_spec_tools.context` module (`gate_satisfied`). That module currently lives on the unpublished spec-tools branch `feat/context-1-gating-helpers`; the floor anticipates its release. Local test install:

```
uv pip install --prerelease=allow "git+https://github.com/OpenVoiceOS/ovos-spec-tools@feat/context-1-gating-helpers"
```

## Tests

8 new tests in `test/test_opm.py` (`TestNebulentoContextGating`): requires present→match, requires absent→drop, excludes present→drop, excludes absent→match, no-gate→match, shared-scope requires, template-topic stores gates, detach clears gates. Full suite: 140 passed.

Base is `feat/intent-4-adoption` (this branch builds on the INTENT-4 consumer surface).

🤖 Generated with [Claude Code](https://claude.com/claude-code)