### PR TITLE
feat: OVOS-CONTEXT-1 §7 context slot fill + OVOS-INTENT-2 §4.3 blacklist

### DIFF
--- a/nebulento/container.py
+++ b/nebulento/container.py
@@ -46,6 +46,11 @@ class IntentContainer:
         self.ignore_case = ignore_case
         self.registered_intents: Dict[str, List[str]] = {}
         self.registered_entities: Dict[str, List[str]] = {}
+        #: OVOS-CONTEXT-1 §7 — per-intent slot-name index, built at
+        #: registration by parsing ``{name}`` placeholders out of the intent's
+        #: templates. Names every declarable slot so context fill can offer a
+        #: candidate for each, independent of ``requires_context``.
+        self.intent_slots: Dict[str, List[str]] = {}
         self.available_contexts: Dict[str, Dict[str, object]] = {}
         self.required_contexts: Dict[str, List[str]] = {}
         self.excluded_contexts: Dict[str, List[str]] = {}
@@ -57,6 +62,15 @@ class IntentContainer:
     def intent_names(self) -> List[str]:
         """Names of all currently registered intents."""
         return list(self.registered_intents)
+
+    def slot_names(self, intent_name: str) -> List[str]:
+        """Return the declared ``{slot}`` names for *intent_name*.
+
+        The names drive OVOS-CONTEXT-1 §7 context fill: every declared slot is
+        eligible for a context-supplied value, whether or not it is gated by
+        ``requires_context``.  Empty list when the intent is unknown or slotless.
+        """
+        return self.intent_slots.get(intent_name, [])
 
     # ── internal helpers ────────────────────────────────────────────────────
 
@@ -96,6 +110,15 @@ class IntentContainer:
             for e in expand_template(normalize_example(line))
         }
         self.registered_intents[name] = list(expanded)
+        # Index every {slot} placeholder declared across the templates so
+        # OVOS-CONTEXT-1 §7 fill can offer a context candidate for each.
+        slots: List[str] = []
+        for sample in expanded:
+            for slot in re.findall(r"\{(\w+)\}", sample):
+                slot = slot.lower()
+                if slot not in slots:
+                    slots.append(slot)
+        self.intent_slots[name] = slots
 
     def remove_intent(self, name: str) -> None:
         """Unregister an intent.  Silently does nothing if *name* is not registered.
@@ -104,6 +127,7 @@ class IntentContainer:
             name: Intent identifier to remove.
         """
         self.registered_intents.pop(name, None)
+        self.intent_slots.pop(name, None)
 
     def add_entity(self, name: str, lines: List[str]) -> None:
         """Register an entity with sample values used to boost match confidence.

--- a/nebulento/hierarchical.py
+++ b/nebulento/hierarchical.py
@@ -153,6 +153,19 @@ class HierarchicalIntentContainer:
         if domain_name in self.domains:
             self.domains[domain_name].remove_entity(entity_name)
 
+    def slot_names(self, intent_name: str) -> List[str]:
+        """Return the declared ``{slot}`` names for *intent_name*.
+
+        Searches every domain's sub-container, since an intent lives under a
+        single domain but callers address it by its flat name.  Drives
+        OVOS-CONTEXT-1 §7 context fill.  Empty list when unknown or slotless.
+        """
+        for domain in self.domains.values():
+            slots = domain.slot_names(intent_name)
+            if slots:
+                return slots
+        return []
+
     # ── query API ──────────────────────────────────────────────────────────
 
     def calc_domain(self, query: str) -> MatchResult:

--- a/nebulento/opm.py
+++ b/nebulento/opm.py
@@ -1,5 +1,6 @@
 """Intent service wrapping Nebulento."""
 
+import re
 from functools import lru_cache
 from os.path import isfile
 from typing import Optional, Dict, List, Union
@@ -10,7 +11,7 @@ from ovos_bus_client.session import SessionManager, Session
 from ovos_config.config import Configuration
 from ovos_plugin_manager.templates.pipeline import ConfidenceMatcherPipeline, IntentHandlerMatch
 from ovos_spec_tools import SpecMessage, closest_lang, standardize_lang
-from ovos_spec_tools.context import gate_satisfied
+from ovos_spec_tools.context import context_slot_candidates, gate_satisfied
 from ovos_utils import flatten_list
 from ovos_utils.fakebus import FakeBus
 from ovos_utils.log import LOG
@@ -116,6 +117,11 @@ class NebulentoPipeline(ConfidenceMatcherPipeline):
         # keys mean "no gate". gate_satisfied() enforces liveness/scope/decay.
         self.requires_context: Dict[str, list] = {}
         self.excludes_context: Dict[str, list] = {}
+        # OVOS-INTENT-2 §4.3 — per-intent slot blacklists, keyed by the
+        # internal ``skill_id:name`` label then by slot name. A slot bound by
+        # the utterance to a blacklisted value is treated as UNRESOLVED, so
+        # OVOS-CONTEXT-1 §7 context fill can supply the intended value instead.
+        self.slot_blacklists: Dict[str, Dict[str, list]] = {}
         LOG.debug("Loaded Nebulento pipeline")
 
     def _store_context_gates(self, name: str, message) -> None:
@@ -131,6 +137,94 @@ class NebulentoPipeline(ConfidenceMatcherPipeline):
             self.requires_context[name] = requires
         if excludes:
             self.excludes_context[name] = excludes
+
+    def _store_slot_blacklist(self, name: str, message) -> None:
+        """Record OVOS-INTENT-2 §4.3 per-slot value exclusions from registration.
+
+        The payload carries a ``slot_blacklist`` (or legacy ``blacklist``) field:
+        a mapping of slot name -> list of excluded values. Stored verbatim and
+        enforced at match time by :meth:`_apply_context_slots`.
+        """
+        blacklist = message.data.get("slot_blacklist") or message.data.get("blacklist")
+        if isinstance(blacklist, dict) and blacklist:
+            self.slot_blacklists[name] = {
+                slot: list(values) for slot, values in blacklist.items()
+            }
+
+    @staticmethod
+    def _value_blacklisted(values, blacklist) -> bool:
+        """True when any bound *values* matches a *blacklist* entry.
+
+        Matching is whole-word-sequence: a blacklisted phrase must appear as a
+        run of complete words within the bound value, so ``"cast"`` does not
+        exclude ``"podcast"``.
+        """
+        if not blacklist:
+            return False
+        for value in values if isinstance(values, (list, tuple)) else [values]:
+            text = str(value).lower()
+            for bad in blacklist:
+                if re.search(r"\b" + re.escape(str(bad).lower()) + r"\b", text):
+                    return True
+        return False
+
+    @staticmethod
+    def _strip_words(text: str, words) -> str:
+        """Remove whole-word occurrences of *words* from *text*."""
+        out = text.lower()
+        for word in words:
+            out = re.sub(r"\b" + re.escape(str(word).lower()) + r"\b", " ", out)
+        return re.sub(r"\s+", " ", out).strip()
+
+    def _apply_context_slots(self, intent: "NebulentoIntent", container,
+                             sess) -> None:
+        """Enforce §4.3 blacklists then apply OVOS-CONTEXT-1 §7 context fill.
+
+        For every declared slot of the matched intent: drop a value the
+        utterance bound to a blacklisted entry (leaving the slot UNRESOLVED),
+        then fill any still-unresolved slot from a live ``intent_context`` entry
+        (private ``<skill_id>:name`` before shared bare ``name``). Utterance
+        values that survive the blacklist always win over context candidates.
+
+        Fill is *prematch injection*: the candidate values are spliced into the
+        utterance (blacklisted words removed first) and the intent re-scored, so
+        a slot supplied purely by context raises confidence exactly as if the
+        speaker had uttered it. The context value is then the authoritative
+        binding for that slot.
+        """
+        skill_id = intent.name.split(":")[0]
+        slot_names = container.slot_names(intent.name)
+        if not slot_names:
+            return
+
+        blacklist = self.slot_blacklists.get(intent.name, {})
+        matches = dict(intent.matches)
+        dropped_words: List[str] = []
+        for slot in slot_names:
+            values = matches.get(slot)
+            if values and self._value_blacklisted(values, blacklist.get(slot)):
+                matches.pop(slot)
+                dropped_words += [str(v) for v in
+                                  (values if isinstance(values, (list, tuple))
+                                   else [values])]
+
+        candidates = context_slot_candidates(sess.intent_context or {},
+                                             slot_names, owner_id=skill_id)
+        # unresolved by any surviving utterance value → eligible for context
+        fills = {slot: value for slot, value in candidates.items()
+                 if not matches.get(slot)}
+
+        if fills:
+            augmented = self._strip_words(intent.sent, dropped_words)
+            augmented = (augmented + " " +
+                         " ".join(str(v) for v in fills.values())).strip()
+            rescored = container.calc_intent(augmented)
+            if rescored and rescored.get("name") == intent.name:
+                intent.conf = rescored["conf"]
+            for slot, value in fills.items():
+                matches[slot] = value
+
+        intent.matches = matches
 
     def _context_gate_ok(self, name: str, sess) -> bool:
         """OVOS-CONTEXT-1 §6 gate for candidate intent *name* under *sess*."""
@@ -226,6 +320,7 @@ class NebulentoPipeline(ConfidenceMatcherPipeline):
         name = message.data["name"]
         self.registered_intents.append(name)
         self._store_context_gates(name, message)
+        self._store_slot_blacklist(name, message)
         container = self.containers[lang]
         try:
             self._register_object(
@@ -271,8 +366,8 @@ class NebulentoPipeline(ConfidenceMatcherPipeline):
         """Consume ``ovos.intent.register.template`` (INTENT-4 §6).
 
         Template intents are nebulento's native definition method. The payload
-        carries inline ``samples`` (OVOS-INTENT-1 templates); ``blacklist`` is a
-        suppression hint nebulento does not yet honour and is ignored.
+        carries inline ``samples`` (OVOS-INTENT-1 templates) and an optional
+        per-slot ``slot_blacklist`` (OVOS-INTENT-2 §4.3) enforced at match time.
         """
         lang = standardize_lang(message.data.get("lang", self.lang))
         if lang not in self.containers:
@@ -287,6 +382,7 @@ class NebulentoPipeline(ConfidenceMatcherPipeline):
             return
         self.registered_intents.append(name)
         self._store_context_gates(name, message)
+        self._store_slot_blacklist(name, message)
         container = self.containers[lang]
         try:
             self._add_intent(container, name, samples)
@@ -358,6 +454,7 @@ class NebulentoPipeline(ConfidenceMatcherPipeline):
             self.registered_intents.remove(intent_name)
             self.requires_context.pop(intent_name, None)
             self.excludes_context.pop(intent_name, None)
+            self.slot_blacklists.pop(intent_name, None)
             for container in self.containers.values():
                 self._remove_intent(container, intent_name)
 
@@ -426,7 +523,12 @@ class NebulentoPipeline(ConfidenceMatcherPipeline):
         # OVOS-CONTEXT-1 §6 — drop candidates whose requires/excludes gate is
         # not satisfied by the session's live intent_context.
         results = [r for r in results if self._context_gate_ok(r.name, sess)]
-        return max(results, key=lambda r: r.conf) if results else None
+        if not results:
+            return None
+        best = max(results, key=lambda r: r.conf)
+        # OVOS-INTENT-2 §4.3 blacklist + OVOS-CONTEXT-1 §7 context slot fill.
+        self._apply_context_slots(best, container, sess)
+        return best
 
     def _get_closest_lang(self, lang: str) -> Optional[str]:
         if not self.containers:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ requires-python = ">=3.10"
 dependencies = [
     "rapidfuzz",
     "quebra_frases",
-    "ovos-spec-tools>=1.4.0a1",
+    "ovos-spec-tools>=1.5.0a1",
     "ovos-utils",
 ]
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 rapidfuzz
 quebra_frases
-ovos-spec-tools>=0.10.0a1
+ovos-spec-tools>=1.5.0a1
 ovos-utils

--- a/test/test_opm.py
+++ b/test/test_opm.py
@@ -517,5 +517,82 @@ class TestNebulentoContextGating(unittest.TestCase):
         self.assertNotIn("test_skill:HelloIntent", self.pipeline.requires_context)
 
 
+class TestNebulentoContextSlotFill(unittest.TestCase):
+    """OVOS-CONTEXT-1 §7 uniform slot fill + OVOS-INTENT-2 §4.3 blacklist."""
+
+    def setUp(self):
+        self.bus = mock.Mock()
+        self.pipeline = NebulentoPipeline(bus=self.bus, config={
+            "conf_high": 0.95, "conf_med": 0.8, "conf_low": 0.5,
+        })
+        # {song} slot, NO requires_context — §7 fill is independent of gating
+        self.pipeline.register_intent(_register_intent_msg(
+            "music_skill:PlayIntent",
+            ["play {song}", "put on {song}"],
+        ))
+        self.pipeline.register_entity(_register_entity_msg(
+            "song", ["jazz", "rock", "the beatles", "podcast"]))
+
+    def _session(self, intent_context):
+        s = Session("slot-test")
+        s.intent_context = intent_context
+        return s
+
+    def _play(self, utt, intent_context):
+        sess = self._session(intent_context)
+        return self.pipeline.match_low([utt], "en-US", _utt_msg(utt, sess))
+
+    def test_slot_filled_from_context_without_requires(self):
+        # utterance leaves {song} unresolved; live context entry supplies it
+        result = self._play("play", {"music_skill:song": {"value": "jazz"}})
+        self.assertIsNotNone(result)
+        self.assertEqual(result.match_data.get("song"), "jazz")
+
+    def test_utterance_value_wins_over_context(self):
+        # utterance binds {song}=rock; context offers jazz but must not override
+        result = self._play("play rock", {"music_skill:song": {"value": "jazz"}})
+        self.assertIsNotNone(result)
+        self.assertEqual(result.match_data.get("song"), ["rock"])
+
+    def test_shared_scope_fills_slot(self):
+        # bare (shared) key, no owner prefix
+        result = self._play("play", {"song": {"value": "rock"}})
+        self.assertIsNotNone(result)
+        self.assertEqual(result.match_data.get("song"), "rock")
+
+    def test_dead_context_entry_does_not_fill(self):
+        # expired entry (turns_remaining == 0) is not live: no injection, so
+        # bare "play" never clears the confidence floor
+        result = self._play("play", {"music_skill:song":
+                                     {"value": "jazz", "turns_remaining": 0}})
+        self.assertIsNone(result)
+
+    def test_blacklisted_value_unresolved_then_context_fills(self):
+        # utterance binds {song}=rock, but rock is blacklisted → unresolved →
+        # §7 context fill supplies jazz instead
+        self.pipeline.slot_blacklists["music_skill:PlayIntent"] = {"song": ["rock"]}
+        result = self._play("play rock", {"music_skill:song": {"value": "jazz"}})
+        self.assertIsNotNone(result)
+        self.assertEqual(result.match_data.get("song"), "jazz")
+
+    def test_blacklist_whole_word_sequence_only(self):
+        # "cast" must not blacklist "podcast"
+        self.pipeline.slot_blacklists["music_skill:PlayIntent"] = {"song": ["cast"]}
+        result = self._play("play podcast", {})
+        self.assertIsNotNone(result)
+        self.assertEqual(result.match_data.get("song"), ["podcast"])
+
+    def test_flag_context_only_gates_no_slot_named(self):
+        # a requires_context flag with no matching slot name never fills a slot
+        self.pipeline.register_intent(_register_intent_msg(
+            "music_skill:StopIntent", ["stop"],
+        ))
+        self.pipeline.requires_context["music_skill:StopIntent"] = ["playing"]
+        sess = self._session({"music_skill:playing": {"value": True}})
+        result = self.pipeline.match_low(["stop"], "en-US", _utt_msg("stop", sess))
+        self.assertIsNotNone(result)
+        self.assertEqual(result.match_data, {})
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Builds on the merged §6 requires/excludes_context gating (#36).

## §7 uniform context slot fill (architecture#103)
- Per-intent slot-name index built at registration by parsing `{name}` placeholders from the expanded templates (`IntentContainer.intent_slots` / `slot_names()`; the hierarchical container delegates to its domains).
- For **every** declared slot of the matched intent, when the utterance leaves it unresolved, the slot is filled from a live `session.intent_context` entry — private `<skill_id>:name` taking precedence over shared bare `name` — via `ovos_spec_tools.context_slot_candidates`. This is **independent of `requires_context`**; `gate_satisfied` continues to gate FLAGS only.
- Fill is **prematch injection**: the candidate value is spliced into the utterance (blacklisted words stripped first) and the intent re-scored, so a context-supplied slot raises fuzzy confidence exactly as if the speaker had uttered it. Surviving utterance values always win over context candidates.

## §4.3 entity blacklist (INTENT-2, architecture#104)
- The per-slot `slot_blacklist` / `blacklist` payload field (keyed by slot name) is stored at registration.
- When the utterance binds a slot to a blacklisted value (whole-word sequence — `"cast"` does not blacklist `"podcast"`), the slot is treated UNRESOLVED so §7 context fill supplies the intended value instead.

## Tests (TDD red→green)
New `TestNebulentoContextSlotFill`: fill from context with no `requires_context`; utterance value wins; shared-scope fill; dead entry does not fill; blacklisted value → unresolved → context fills; whole-word-sequence blacklist; flag-only context never fills a slot. Full suite green (fresh uv venv, `--prerelease=allow`), no importorskip/xfail.

## Pin
`ovos-spec-tools>=1.5.0a1` (adds `context_slot_candidates`; from OpenVoiceOS/ovos-spec-tools branch `feat/context-slot-candidates`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)